### PR TITLE
Update Mem.pm to fix malformed XML on Mac OS

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
@@ -56,6 +56,8 @@ sub run {
         if ($desc !~ /empty/ && $desc =~ s/^0x//) {
             # dimm_part_number is an hex string, convert it to ascii
             $desc =~ s/^0x//;
+	    # Trim filling "00" from part number, which causes invalid XML down the line.
+	    $desc =~ s/00//g;
             $desc = pack "H*", $desc;
             $desc =~ s/\s+$//;
             # New macs might have some specific characters, perform a regex to fix it


### PR DESCRIPTION
Trim filling "00" from part number, which causes invalid XML down the line.

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
READY

## Description
Fixes the problem described in this issue: https://github.com/OCSInventory-NG/UnixAgent/issues/407 .

An example of part number: 0x4544464232333241314D412D4A442D460000
which convert the "00" "00" at the end by the NULL ascii character, which renders as a "malformed XML" down the line.
This PR removes the "00" before parsing the values.

## Related Issues

https://github.com/OCSInventory-NG/UnixAgent/issues/407

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Mac OS 12.3.1
Perl version : This is perl 5, version 30, subversion 3 (v5.30.3) built for darwin-thread-multi-2level

#### OCS Inventory informations
Unix agent version : 2.9.2 + modifications in this PR

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Mem.pm component for MacOS
